### PR TITLE
Add Make and Name of Inverter

### DIFF
--- a/kostal/const.py
+++ b/kostal/const.py
@@ -67,6 +67,11 @@ Home = {
     'operatingStatus': 16780032,
 }
 
+SettingsGeneral = {
+    'InverterName': 16777984,
+    'InverterMake': 16780544
+}
+
 InfoVersions = {
     'VersionUI': 16779267,
     'VersionFW': 16779265,


### PR DESCRIPTION
Hi,

thanks for your great library. I am planning to make use of it in a Home Assistant component.
For that I need to access the make and name of the inverter and figured I might as well add it :)

Lmk if this if fine for you!


Thanks in advance

David