### PR TITLE
Add support for reading inverter event history

### DIFF
--- a/kostal/InfoEvents.py
+++ b/kostal/InfoEvents.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+from kostal.DxsApi import DxsEntry
+
+
+@dataclass(frozen=True)
+class Event:
+    timestamp: int
+    date: datetime
+    code: int
+    env: str
+    raw: tuple[int, ...]
+
+
+class InfoEvents:
+    EVENT_COUNT = 234881792
+    FIRST_EVENT = 234881537
+    MAX_EVENTS = 10
+    EVENT_IDS = tuple(range(FIRST_EVENT, FIRST_EVENT + MAX_EVENTS))
+
+    def __init__(self, inverter) -> None:
+        self.__inverter = inverter
+
+    async def events(self) -> list[Event]:
+        response = await self.__inverter.fetch_props(self.EVENT_COUNT, *self.EVENT_IDS)
+        count_entry = response.get_entry_by_id(self.EVENT_COUNT)
+        count = self.__event_count(count_entry)
+
+        events = []
+        for dxs_id in self.EVENT_IDS[:count]:
+            entry = response.get_entry_by_id(dxs_id)
+            event = self.parse_event(entry.value if entry is not None else None)
+            if event is not None:
+                events.append(event)
+
+        return events
+
+    @staticmethod
+    def parse_event(value: list[int] | None) -> Optional[Event]:
+        if value is None or len(value) != 8 or all(part == 0 for part in value):
+            return None
+
+        timestamp = (
+            (value[0] << 0)
+            + (value[1] << 8)
+            + (value[2] << 16)
+            + (value[3] << 24)
+        )
+        code = (value[4] << 0) + (value[5] << 8)
+        env = f"{((value[6] << 0) + (value[7] << 8)):04X}h"
+
+        return Event(
+            timestamp=timestamp,
+            date=datetime.fromtimestamp(timestamp, tz=timezone.utc),
+            code=code,
+            env=env,
+            raw=tuple(value),
+        )
+
+    @staticmethod
+    def __event_count(entry: DxsEntry | None) -> int:
+        if entry is None:
+            return 0
+        return max(0, min(int(entry.value), InfoEvents.MAX_EVENTS))

--- a/kostal/__init__.py
+++ b/kostal/__init__.py
@@ -16,6 +16,8 @@ from kostal.ActualGrid import ActualGrid
 from kostal.ActualHome import ActualHome
 from kostal.ActualSZeroIn import ActualSZeroIn
 from kostal.Home import Home
+from kostal.InfoEvents import Event
+from kostal.InfoEvents import InfoEvents
 from kostal.InfoVersions import InfoVersions
 from kostal.SettingsGeneral import SettingsGeneral
 from kostal.StatisticDay import StatisticDay
@@ -64,6 +66,7 @@ class Piko:
         self.actualHome = ActualHome(self)
         self.actualSZeroIn = ActualSZeroIn(self)
         self.home = Home(self)
+        self.infoEvents = InfoEvents(self)
         self.infoVersions = InfoVersions(self)
         self.settingsGeneral = SettingsGeneral(self)
         self.statisticDay = StatisticDay(self)

--- a/test_piko.py
+++ b/test_piko.py
@@ -1,6 +1,8 @@
 import kostal
 import json
 import asyncio
+from kostal.DxsApi import DxsResponse
+from kostal.InfoEvents import InfoEvents
 from kostal.StatisticDay import StatisticDay
 
 def piko_statistic_day_yield():
@@ -27,3 +29,50 @@ def test_json():
     result = kostal.DxsResponse(**resp)
     entry = result.get_entry_by_id(StatisticDay.YIELD)
     print(entry.dxsId, 'corresponds to', entry.value)
+
+
+def test_parse_event():
+    event = InfoEvents.parse_event([36, 90, 91, 106, 98, 17, 83, 0])
+
+    assert event.timestamp == 1784371748
+    assert event.date.isoformat() == "2026-07-18T10:49:08+00:00"
+    assert event.code == 4450
+    assert event.env == "0053h"
+    assert event.raw == (36, 90, 91, 106, 98, 17, 83, 0)
+
+
+def test_parse_empty_event():
+    assert InfoEvents.parse_event([0, 0, 0, 0, 0, 0, 0, 0]) is None
+
+
+def test_events():
+    class FakeInverter:
+        async def fetch_props(self, *prop_ids):
+            assert prop_ids == (
+                InfoEvents.EVENT_COUNT,
+                *InfoEvents.EVENT_IDS,
+            )
+            return DxsResponse(
+                dxsEntries=[
+                    {"dxsId": InfoEvents.EVENT_COUNT, "value": 3},
+                    {
+                        "dxsId": InfoEvents.FIRST_EVENT,
+                        "value": [36, 90, 91, 106, 98, 17, 83, 0],
+                    },
+                    {
+                        "dxsId": InfoEvents.FIRST_EVENT + 1,
+                        "value": [164, 25, 91, 106, 98, 17, 94, 0],
+                    },
+                    {
+                        "dxsId": InfoEvents.FIRST_EVENT + 2,
+                        "value": [42, 251, 89, 106, 98, 17, 81, 0],
+                    },
+                ],
+                session={"sessionId": 784459231, "roleId": 2},
+                status={"code": 0},
+            )
+
+    events = asyncio.run(InfoEvents(FakeInverter()).events())
+
+    assert [event.code for event in events] == [4450, 4450, 4450]
+    assert [event.env for event in events] == ["0053h", "005Eh", "0051h"]


### PR DESCRIPTION
This adds support for reading the PIKO inverter event history through the existing DXS API.

The inverter exposes the event count at DXS ID 234881792 and up to ten event slots starting at 234881537. Each event slot contains an 8-byte payload:

```
bytes 0-3: little-endian Unix timestamp
bytes 4-5: little-endian event code
bytes 6-7: little-endian environment/context code
```

Tests are written using payloads captured from a real PIKO 12 inverter.